### PR TITLE
[FEATURE] Add slot for allowing ip-based authentication

### DIFF
--- a/Classes/Slot/AddCustomGroupsSlot.php
+++ b/Classes/Slot/AddCustomGroupsSlot.php
@@ -1,0 +1,26 @@
+<?php
+namespace In2code\In2frontendauthentication\Slot;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use In2code\In2frontendauthentication\Domain\Repository\FeGroupsRepository;
+
+class AddCustomGroupsSlot
+{
+
+    public function addCustomGroups($checkPermissions)
+    {
+        $feGroupsRepository = GeneralUtility::makeInstance(ObjectManager::class)
+            ->get(FeGroupsRepository::class);
+        $feGroups = $feGroupsRepository->findByCurrentIpAddress();
+
+
+
+        $customGroups = [];
+        foreach ($feGroups as $feGroup) {
+            $customGroups[] = $feGroup['uid'];
+        }
+
+        $checkPermissions->addCustomGroups($customGroups);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,3 +17,14 @@ defined('TYPO3_MODE') || die();
         'className' => \In2code\In2frontendauthentication\Domain\Service\AuthenticationService::class,
     ]
 );
+
+/** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
+$signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
+$signalSlotDispatcher->connect(
+    \BeechIt\FalSecuredownload\Security\CheckPermissions::class,
+    'AddCustomGroups',
+    \In2code\In2frontendauthentication\Slot\AddCustomGroupsSlot::class,
+    'addCustomGroups'
+);
+
+


### PR DESCRIPTION
Hi,

this patch provides a slot to be able to use ip based authentication with "EXT:fal_securedownload". 

The signal ist implemented here: 

https://github.com/mschwemer/fal_securedownload/tree/feature/add-slot-for-authentication

Cheers,
Marcus 