### PR TITLE
[FEATURE] Set the staticfilecache cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Set ip addresses in fe_groups.
 **Note:** This allows you to show/hide contentelements, pages and other records to a specific usergroup.
 But "showAtAnyLogin" or "hideAtAnyLogin" is not supported at the moment.
 
+## Static File Cache
+
+The extension staticfilecache sets a cookie to identify, whether a user is logged in and the static file cache may not
+be used. It hooks into the normal authentication process, when the user is initialized. With 
+EXT:in2frontendauthentication there are no specific frontend users, so it must be set here too.
+
+This feature can be enabled in the extension settings in the extension manager. 
+
 ## Supported TYPO3-Versions
 
 * TYPO3 8.7

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic/enable;; type=boolean; label=Set "staticfilecache" cookie, if extension is installed
+set_sfc_cookie =


### PR DESCRIPTION
EXT:staticfilecache uses a separate cookie to identify, whether a user
is logged in or not. This requires a TYPO3 standard login, which this
 extension does not use. So the cookie must be set through this
 extension.