### PR TITLE
[BUGFIX] Use correct namespace for CookieService

### DIFF
--- a/Classes/Domain/Service/AuthenticationService.php
+++ b/Classes/Domain/Service/AuthenticationService.php
@@ -72,7 +72,7 @@ class AuthenticationService extends AuthenticationServiceCore
             $setSfcCookie = $extensionConfiguration['set_sfc_cookie'];
 
             $cookieService = GeneralUtility::makeInstance(
-                \SFC\Staticfilecache\Service\CookieService\CookieService::class
+                \SFC\Staticfilecache\Service\CookieService::class
             );
 
             if ($setSfcCookie === '1' && $ipBasedLogin === true) {


### PR DESCRIPTION
There was an additional path segmant in the instantiation of the class
`\SFC\Staticfilecache\Service\CookieService::class`