### PR TITLE
[BUGFIX] Fix access to settings value

### DIFF
--- a/Classes/Domain/Service/AuthenticationService.php
+++ b/Classes/Domain/Service/AuthenticationService.php
@@ -75,7 +75,7 @@ class AuthenticationService extends AuthenticationServiceCore
                 \SFC\Staticfilecache\Service\CookieService::class
             );
 
-            if ($setSfcCookie === '1' && $ipBasedLogin === true) {
+            if ($setSfcCookie['value'] === '1' && $ipBasedLogin === true) {
                 $cookieService->setCookie(time() + 3600);
             } else {
                 $cookieService->setCookie(time() - 3600);


### PR DESCRIPTION
Using the API to access a configuration value, returns an array, not
just the config value itself.