### PR TITLE
MySQL sql_mode ANSI_QUOTES support

### DIFF
--- a/Classes/Domain/Repository/FeGroupsRepository.php
+++ b/Classes/Domain/Repository/FeGroupsRepository.php
@@ -87,7 +87,7 @@ class FeGroupsRepository
         return (array)$queryBuilder
             ->select('*')
             ->from(self::TABLE_NAME)
-            ->where('ip_mask != ""')
+            ->where('ip_mask != \'\'')
             ->executeQuery()
             ->fetchAllAssociative();
     }


### PR DESCRIPTION
## Issue

FeGroupsRepository::getAllGroupsWithIpConfiguration uses double quotes to check for an empty string, but if the MySQL sql_mode has ANSI_QUOTES enabled, this will return an error.

## Changes

- Updated FeGroupsRepository.php to swap double-quotes with single quotes